### PR TITLE
Extend vertigo with trivial compiler equivalence check

### DIFF
--- a/eth_vertigo/cli/main.py
+++ b/eth_vertigo/cli/main.py
@@ -74,6 +74,8 @@ def run(output, network, truffle_location, sample_ratio, exclude):
             click.echo("[-] We couldn't get valid results by running the truffle tests.\n Aborting")
             return
         click.echo("[+] The project is valid")
+        click.echo("[*] Storing compilation results")
+        campaign.store_compilation_results()
         click.echo("[*] Running analysis on {} mutants".format(len(campaign.mutations)))
         with tqdm(total=len(campaign.mutations), unit="mutant") as pbar:
             report = campaign.run(lambda: pbar.update(1) and pbar.refresh(), threads=max(len(network), 1))

--- a/eth_vertigo/mutation/campaign.py
+++ b/eth_vertigo/mutation/campaign.py
@@ -79,3 +79,6 @@ class Campaign:
         """ Checks whether the current project is valid """
         raise NotImplementedError
 
+    def store_compilation_results(self):
+        """ Stores compilation results for trivial compiler equivalence"""
+        raise NotImplementedError

--- a/eth_vertigo/mutation/mutation.py
+++ b/eth_vertigo/mutation/mutation.py
@@ -13,6 +13,7 @@ class MutationResult(Enum):
     LIVED = 2
     TIMEDOUT = 3
     ERROR = 4
+    EQUIVALENT = 5
 
 
 _mutationresult_string = {
@@ -20,8 +21,10 @@ _mutationresult_string = {
     MutationResult.LIVED: "Lived",
     MutationResult.TIMEDOUT: "Timeout",
     MutationResult.ERROR: "Error",
+    MutationResult.EQUIVALENT: "Equivalent",
     None: "None"
 }
+
 
 class Mutation:
     """

--- a/eth_vertigo/mutation/truffle/truffle_campaign.py
+++ b/eth_vertigo/mutation/truffle/truffle_campaign.py
@@ -86,7 +86,12 @@ class TruffleCampaign(Campaign):
         if self.networks:
             network = self.networks_queue.get()
         try:
-            test_result = tr.run_tests(mutation=mutation, timeout=int(self.base_run_time) * 2, network=network)
+            test_result = tr.run_tests(
+                mutation=mutation,
+                timeout=int(self.base_run_time) * 2,
+                network=network,
+                original_bytecode=self.bytecodes
+            )
             if any(map(lambda t: not t.success, test_result.values())):
                 mutation.result = MutationResult.KILLED
         except TimedOut:

--- a/eth_vertigo/mutation/truffle/truffle_campaign.py
+++ b/eth_vertigo/mutation/truffle/truffle_campaign.py
@@ -29,6 +29,7 @@ class TruffleCampaign(Campaign):
         self.base_run_time = None
         self.networks = networks
         self.networks_queue = Queue(maxsize=len(networks))
+        self.bytecodes = {}
 
         self.truffle_runner_factory = truffle_runner_factory
 
@@ -99,3 +100,6 @@ class TruffleCampaign(Campaign):
             done_callback()
             return
 
+    def store_compilation_results(self):
+        """ Stores compilation results for trivial compiler equivalence"""
+        self.bytecodes = self.truffle_compiler.get_bytecodes(working_directory=str(self.project_directory))

--- a/eth_vertigo/mutation/truffle/truffle_compiler.py
+++ b/eth_vertigo/mutation/truffle/truffle_compiler.py
@@ -1,8 +1,19 @@
+from typing import Dict
+
+
 class TruffleCompiler:
     """Truffle compiler interface exposes compiling functionality from truffle"""
     def run_compile_command(self, working_directory: str) -> None:
         """ Runs truffle's test command
 
         :param working_directory: The truffle project directory to compile
+        """
+        raise NotImplementedError
+
+    def get_bytecodes(self, working_directory: str) -> Dict[str, str]:
+        """ Returns the bytecodes in the compilation result of the current directory
+
+        :param working_directory: The truffle directory for which we retreive the bytecodes
+        :return: bytecodes in the shape {'contractName': '0x00'}
         """
         raise NotImplementedError

--- a/eth_vertigo/test_runner/exceptions.py
+++ b/eth_vertigo/test_runner/exceptions.py
@@ -8,3 +8,6 @@ class TimedOut(Exception):
 
 class DidNotCompile(Exception):
     pass
+
+class EquivalentMutant(Exception):
+    pass

--- a/eth_vertigo/test_runner/truffle/truffle_runner.py
+++ b/eth_vertigo/test_runner/truffle/truffle_runner.py
@@ -1,6 +1,7 @@
 from eth_vertigo.test_runner import Runner
 from eth_vertigo.test_runner.file_editor import FileEditor
 from eth_vertigo.test_runner.truffle.truffle_tester import TruffleTester
+from eth_vertigo.test_runner.exceptions import EquivalentMutant
 from eth_vertigo.mutation import Mutation, MutationResult
 from typing import Generator
 
@@ -60,7 +61,7 @@ class TruffleRunner(Runner):
             _apply_mutation(mutation, temp_dir)
         try:
             if original_bytecode and self.truffle_tester.check_bytecodes(temp_dir, original_bytecode):
-                result = MutationResult.EQUIVALENT
+                raise EquivalentMutant
             else:
                 result = self.truffle_tester.run_test_command(temp_dir, timeout=timeout, network_name=network)
         finally:

--- a/eth_vertigo/test_runner/truffle/truffle_runner.py
+++ b/eth_vertigo/test_runner/truffle/truffle_runner.py
@@ -1,7 +1,7 @@
 from eth_vertigo.test_runner import Runner
 from eth_vertigo.test_runner.file_editor import FileEditor
 from eth_vertigo.test_runner.truffle.truffle_tester import TruffleTester
-from eth_vertigo.mutation import Mutation
+from eth_vertigo.mutation import Mutation, MutationResult
 from typing import Generator
 
 from pathlib import Path
@@ -59,10 +59,10 @@ class TruffleRunner(Runner):
         if mutation:
             _apply_mutation(mutation, temp_dir)
         try:
-            if self.truffle_tester.check_bytecodes(temp_dir, original_bytecode):
-                # This is an equivalent mutant
-                pass
-            result = self.truffle_tester.run_test_command(temp_dir, timeout=timeout, network_name=network)
+            if original_bytecode and self.truffle_tester.check_bytecodes(temp_dir, original_bytecode):
+                result = MutationResult.EQUIVALENT
+            else:
+                result = self.truffle_tester.run_test_command(temp_dir, timeout=timeout, network_name=network)
         finally:
             _rm_temp_truffle_directory(temp_dir)
 

--- a/eth_vertigo/test_runner/truffle/truffle_runner.py
+++ b/eth_vertigo/test_runner/truffle/truffle_runner.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from tempfile import mkdtemp
 from distutils.dir_util import copy_tree
 import shutil
-
+from typing import Dict
 
 def _make_temp_truffle_directory(original_dir: str):
     td = mkdtemp()
@@ -44,7 +44,7 @@ class TruffleRunner(Runner):
     def tests(self) -> Generator[str, None, None]:
         raise NotImplementedError
 
-    def run_tests(self, coverage: bool = False, mutation: Mutation = None, timeout=None, network=None) -> dict:
+    def run_tests(self, coverage: bool = False, mutation: Mutation = None, timeout=None, network: str = None, original_bytecode: Dict[str, str] = None) -> dict:
         """
         Runs all the tests in the truffle project in a clean environment
         :param coverage: Whether to run the tests with coverage
@@ -58,8 +58,10 @@ class TruffleRunner(Runner):
         _set_reporter(temp_dir)
         if mutation:
             _apply_mutation(mutation, temp_dir)
-
         try:
+            if self.truffle_tester.check_bytecodes(temp_dir, original_bytecode):
+                # This is an equivalent mutant
+                pass
             result = self.truffle_tester.run_test_command(temp_dir, timeout=timeout, network_name=network)
         finally:
             _rm_temp_truffle_directory(temp_dir)

--- a/eth_vertigo/test_runner/truffle/truffle_tester.py
+++ b/eth_vertigo/test_runner/truffle/truffle_tester.py
@@ -15,3 +15,12 @@ class TruffleTester:
         :return: The test results
         """
         raise NotImplementedError
+
+    def check_bytecodes(self, working_directory:str, original_bytecode: Dict[str, str]) -> bool:
+        """ Returns whether any of the bytecodes differ from the original bytecodes
+
+        :param working_directory: The truffle directory for which we should check the bytecodes
+        :param original_bytecode: The original bytecodes {'contractName': '0x00'}
+        :return: Whether the bytecodes match up
+        """
+        raise NotImplementedError

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pytest
 click
 tqdm
 jinja2
+loguru


### PR DESCRIPTION
In this pr I have added a feature which leverages the solidity compiler to filter some equivalent mutants.

The essence of the optimisation is the following:
If the mutant and original program have the same bytecodes, then they must be semantically equivalent (assuming that there are no bugs in the solidity compiler ofc).