### PR TITLE
fixes #15 windows-incompatible path-based test

### DIFF
--- a/test/mutation/test_mutation.py
+++ b/test/mutation/test_mutation.py
@@ -39,7 +39,7 @@ def test_relative_path(tmp_path):
     relative_path = mutation.relative_path
 
     # Assert
-    assert "testdir/sf.txt" == relative_path
+    assert Path("testdir/sf.txt") == Path(relative_path)
 
 
 def test_get_mutated_line(tmp_path):


### PR DESCRIPTION
Running the tests on windows results in:

>       assert "testdir/sf.txt" == relative_path
E       AssertionError: assert 'testdir/sf.txt' == 'testdir\\sf.txt'
E         - testdir/sf.txt
E         ?        ^
E         + testdir\sf.txt
E         ?        ^

test\mutation\test_mutation.py:42: AssertionError

This fixes this test by creating Path objects for the expected path and
relative path.