### PR TITLE
fix(test_runner/truffle/truffle_runner): copy project directory with symlinks preserved

### DIFF
--- a/eth_vertigo/test_runner/truffle/truffle_runner.py
+++ b/eth_vertigo/test_runner/truffle/truffle_runner.py
@@ -13,7 +13,7 @@ from typing import Dict
 
 def _make_temp_truffle_directory(original_dir: str):
     td = mkdtemp()
-    copy_tree(original_dir, td)
+    copy_tree(original_dir, td, preserve_symlinks=1)
     return td
 
 


### PR DESCRIPTION
This PR is a joint work with @iczc .

Truffle Solidity projects normally require installing dependencies via `npm`. When copying the project directory, the `npm` dependency directory `node_modules` is also copied over. When the symlinks are not preserved and resolved to the pointed files then copy, the files in `node_modules` that were symlinks will then be normal files. This is a problem when such files try to `require` other files using relative paths. The relative paths will be broken since those normal files are residing in places that they aren't designed to be.