### PR TITLE
Add dynamic networks 🚀

### DIFF
--- a/eth_vertigo/core/network/__init__.py
+++ b/eth_vertigo/core/network/__init__.py
@@ -1,0 +1,3 @@
+from eth_vertigo.core.network.ganache import Ganache
+
+from eth_vertigo.core.network.pool import NetworkPool, StaticNetworkPool, DynamicNetworkPool

--- a/eth_vertigo/core/network/ganache.py
+++ b/eth_vertigo/core/network/ganache.py
@@ -1,0 +1,35 @@
+import subprocess
+from typing import Optional
+DEFAULT_GANACHE_PARAMETERS = ["--dbMemdown"]
+
+
+class Ganache:
+    def __init__(self, ganache_binary="ganache", parameters=()):
+        # Remove any pre-set port options
+        self.parameters = [p for p in parameters if "--port" not in p]
+
+        for param in DEFAULT_GANACHE_PARAMETERS:
+            if param in self.parameters:
+                continue
+            self.parameters.append(param)
+
+        self.ganache_binary = ganache_binary
+        self.process = None  # type: Optional[subprocess.Popen]
+
+    def start(self):
+        if self.process is not None:
+            raise ValueError("Process has already been terminated")
+
+        self.process = subprocess.Popen(
+            [self.ganache_binary] + self.parameters
+        )
+
+        if self.process.poll() is None:
+            raise Exception("Could not create ganache network")
+
+    def stop(self):
+        if self.process is None:
+            raise ValueError("Process has not yet been started")
+        if self.process.poll() is None:
+            raise ValueError("Process has already terminated")
+        self.process.terminate()

--- a/eth_vertigo/core/network/ganache.py
+++ b/eth_vertigo/core/network/ganache.py
@@ -1,12 +1,16 @@
-import subprocess
+from subprocess import Popen, run, getoutput,  PIPE
 from typing import Optional
-DEFAULT_GANACHE_PARAMETERS = ["--dbMemdown"]
+from tempfile import TemporaryFile
+from time import sleep
+from loguru import logger
+DEFAULT_GANACHE_PARAMETERS = []  # ["--dbMemdown"]
 
 
 class Ganache:
-    def __init__(self, ganache_binary="ganache", parameters=()):
+    def __init__(self, port, ganache_binary="ganache", parameters=()):
         # Remove any pre-set port options
         self.parameters = [p for p in parameters if "--port" not in p]
+        self.parameters.append(f"--port {port}")
 
         for param in DEFAULT_GANACHE_PARAMETERS:
             if param in self.parameters:
@@ -20,16 +24,17 @@ class Ganache:
         if self.process is not None:
             raise ValueError("Process has already been terminated")
 
-        self.process = subprocess.Popen(
-            [self.ganache_binary] + self.parameters
+        self.process = Popen(
+            [self.ganache_binary] + [' '.join(self.parameters)],
+            stderr=PIPE, stdout=PIPE
         )
 
-        if self.process.poll() is None:
+        if self.process.poll() is not None:
             raise Exception("Could not create ganache network")
 
     def stop(self):
         if self.process is None:
             raise ValueError("Process has not yet been started")
-        if self.process.poll() is None:
+        if self.process.poll():
             raise ValueError("Process has already terminated")
         self.process.terminate()

--- a/eth_vertigo/core/network/pool.py
+++ b/eth_vertigo/core/network/pool.py
@@ -19,9 +19,9 @@ class NetworkPool(ABC):
         pass
 
 
-class StaticNetworkPool:
+class StaticNetworkPool(NetworkPool):
     def __init__(self, networks: List[str]):
-        self.available_networks = []
+        self.available_networks = list(networks)
         self.claimed_networks = []
 
     def claim(self) -> str:
@@ -40,7 +40,7 @@ class StaticNetworkPool:
         self.available_networks.append(network)
 
 
-class DynamicNetworkPool:
+class DynamicNetworkPool(NetworkPool):
     def __init__(self, networks: List[Tuple[str, int]], builder: Callable):
         self.available_networks = {n[0]: Network(n[0], n[1]) for n in networks}  # type: Dict
         self.claimed_networks = {}
@@ -55,11 +55,11 @@ class DynamicNetworkPool:
 
         # Put it in the claimed networks
         self.claimed_networks[network.name] = network
-        self.claimed_networks.provider = self.builder(network.port)
+        network.provider = self.builder(network.port)
 
         # Spin up the dynamic network
         try:
-            self.claimed_networks.provider.start()
+            network.provider.start()
         except ValueError:
             raise
 

--- a/eth_vertigo/core/network/pool.py
+++ b/eth_vertigo/core/network/pool.py
@@ -1,0 +1,81 @@
+from abc import abstractmethod, ABC
+from typing import Tuple, Callable, List, Dict
+
+
+class Network:
+    def __init__(self, name: str, port: int, provider=None):
+        self.name = name
+        self.port = port
+        self.provider = provider
+
+
+class NetworkPool(ABC):
+    @abstractmethod
+    def claim(self) -> str:
+        pass
+
+    @abstractmethod
+    def yield_network(self, network: str):
+        pass
+
+
+class StaticNetworkPool:
+    def __init__(self, networks: List[str]):
+        self.available_networks = []
+        self.claimed_networks = []
+
+    def claim(self) -> str:
+        if not self.available_networks:
+            raise ValueError("No network available")
+
+        network = self.available_networks.pop()
+        self.claimed_networks.append(network)
+
+        return network
+
+    def yield_network(self, network: str):
+        if network not in self.claimed_networks:
+            raise ValueError("Trying to yield unclaimed network")
+        self.claimed_networks.remove(network)
+        self.available_networks.append(network)
+
+
+class DynamicNetworkPool:
+    def __init__(self, networks: List[Tuple[str, int]], builder: Callable):
+        self.available_networks = {n[0]: Network(n[0], n[1]) for n in networks}  # type: Dict
+        self.claimed_networks = {}
+        self.builder = builder
+
+    def claim(self) -> str:
+        if not self.available_networks:
+            raise ValueError("No network available")
+
+        # Claim one network from the available networks
+        network = self.available_networks.pop(list(self.available_networks.keys())[0])
+
+        # Put it in the claimed networks
+        self.claimed_networks[network.name] = network
+        self.claimed_networks.provider = self.builder(network.port)
+
+        # Spin up the dynamic network
+        try:
+            self.claimed_networks.provider.start()
+        except ValueError:
+            raise
+
+        return network.name
+
+    def yield_network(self, network: str):
+        if network not in self.claimed_networks:
+            raise ValueError("Network not claimed")
+
+        network = self.claimed_networks.pop(network)
+
+        # Spin down the dynamic network
+        try:
+            network.provider.stop()
+        except ValueError:
+            raise
+
+        # Yield the network back
+        self.available_networks[network.name] = network


### PR DESCRIPTION
We'll get even more value out of this once https://github.com/trufflesuite/ganache-cli/pull/798 is merged. Which will save a bunch of hard disks 🎉 

## Summary
In this PR I've added support for dynamic ganache networks. This means that Vertigo will now handle spinning up and down ganache networks.

Example:
```
vertigo run --ganache-network vertigo1 8545 --ganache-network-options "--gaslimit 10000000"
```